### PR TITLE
Convert cron task to object format

### DIFF
--- a/cron-task.js
+++ b/cron-task.js
@@ -1,36 +1,39 @@
 module.exports = {
-  "*/30 * * * *": async ({ strapi }) => {
-    const posts = await strapi.db
-      .query("plugin::scheduler.scheduler")
-      .findMany({ where: { scheduledDatetime: { $lte: new Date() } } });
-          
-    posts.map(async (post) => {
-    if (post.scheduleType === "schedule") {
+  webbioSchedulerCron: {
+    rule: "*/30 * * * *",
+    task: async ({ strapi }) => {
+      const posts = await strapi.db
+        .query("plugin::scheduler.scheduler")
+        .findMany({ where: { scheduledDatetime: { $lte: new Date() } } });
 
-      await strapi.db.query(post.uid).update({
-        where: {
-          id: post.contentId,
-        },
-        data: {
-          publishedAt: new Date(),
-        },
+      posts.map(async (post) => {
+        if (post.scheduleType === "schedule") {
+
+          await strapi.db.query(post.uid).update({
+            where: {
+              id: post.contentId,
+            },
+            data: {
+              publishedAt: new Date(),
+            },
+          });
+          await strapi.db
+            .query("plugin::scheduler.scheduler")
+            .delete({ where: { id: post.id } });
+        } else if (post.scheduleType === "depublish") {
+          await strapi.db.query(post.uid).update({
+            where: {
+              id: post.contentId,
+            },
+            data: {
+              publishedAt: null,
+            },
+          });
+          await strapi.db
+            .query("plugin::scheduler.scheduler")
+            .delete({ where: { id: post.id } });
+        }
       });
-      await strapi.db
-        .query("plugin::scheduler.scheduler")
-        .delete({ where: { id: post.id } });
-    } else if (post.scheduleType === "depublish") {
-      await strapi.db.query(post.uid).update({
-        where: {
-          id: post.contentId,
-        },
-        data: {
-          publishedAt: null,
-        },
-      });
-      await strapi.db
-        .query("plugin::scheduler.scheduler")
-        .delete({ where: { id: post.id } });
-    }
-  });
-},
+    },
+  }
 };


### PR DESCRIPTION
I converted the cron task to object format so it can integrate with my plugin: https://github.com/excl-networks/strapi-plugin-redcron

This is fully supported by Strapi as you can see here: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.html

This will allow people who are horizontally scaling strapi to prevent race conditions. (i.e only 1 strapi instance will run the cron job.

Also not sure if you knew this but you can programmatically add cron jobs in the bootstrap function. This could make it easier for  users to configure the plugin.

```js
strapi.cron.add({
      myJob: {
        task: async ({ strapi }) => {
          console.log("hello from bootstrap")
        },
        options: {
            rule: '*/10 * * * * *',
        }
      },
    })
```

See: https://docs.strapi.io/developer-docs/latest/developer-resources/plugin-api-reference/server.html#cron